### PR TITLE
Match patch style.

### DIFF
--- a/pyglow/models/f2py/iri12/Makefile
+++ b/pyglow/models/f2py/iri12/Makefile
@@ -1,4 +1,4 @@
-fortran_files = cira.for igrf.for iridreg.for irifun.for irisub.for iritec.for iriflip.for
+fortran_files = cira.for igrf.for iridreg_modified.for irifun.for irisub.for iritec.for iriflip.for
 only = iri_sub
 mod = iri12py
 
@@ -19,7 +19,7 @@ test_ifort:
 #	f77 -o test_gfortran.x tims_iri11_driver.for irisub.for irifun.for iritec.for iridreg.for igrf.for cira.for iriflip.for
 
 patch_iridreg:
-	patch iridreg.for -i iridreg.patch
+	patch iridreg.for -i iridreg.patch -o iridreg_modified.for
 
 patch_iriflip:
 	python delete_iriflip_comments.py

--- a/pyglow/models/f2py/iri16/Makefile
+++ b/pyglow/models/f2py/iri16/Makefile
@@ -1,4 +1,4 @@
-fortran_files = cira.for igrf.for iridreg.for irifun.for irisub.for iritec.for iriflip_modified.for cosd_sind.for
+fortran_files = cira.for igrf.for iridreg_modified.for irifun.for irisub.for iritec.for iriflip_modified.for cosd_sind.for
 only = iri_sub read_ig_rz readapf107
 mod = iri16py
 
@@ -20,7 +20,7 @@ test_gfortran:
 	gfortran $(f77flags) -o test_gfortran.x simple_iri_driver.for $(fortran_files)
 
 patch_iridreg:
-	patch iridreg.for -i iridreg.patch
+	patch iridreg.for -i iridreg.patch -o iridreg_modified.for
 
 patch_iriflip:
 	python delete_iriflip_comments.py


### PR DESCRIPTION
Don't overwrite files. Instead, output _modified versions for
compilation.