### PR TITLE
Python 3 for more platforms

### DIFF
--- a/pyglow/models/Makefile
+++ b/pyglow/models/Makefile
@@ -1,33 +1,51 @@
 
-all:
-	python get_models.py
-
-	cp ./f2py/igrf11/* ./dl_models/igrf11/
+all: source
 	cd ./dl_models/igrf11/; make compile
-	
-	cp ./f2py/igrf12/* ./dl_models/igrf12/
+
 	cd ./dl_models/igrf12/; make compile
 
-	cp ./f2py/msis/* ./dl_models/msis/
 	cd ./dl_models/msis/; make compile;
 
-	cp ./f2py/hwm93/* ./dl_models/hwm93/
 	cd ./dl_models/hwm93/; make compile;
 
-	cp ./f2py/iri12/* ./dl_models/iri12/
 	cd ./dl_models/iri12/; make compile;
 
-	cp ./f2py/iri16/* ./dl_models/iri16/
 	cd ./dl_models/iri16/; make compile;
 
-	cp ./f2py/hwm07/* ./dl_models/hwm07/
 	cd ./dl_models/hwm07/; make compile;
-	
+
 	cd ./dl_models/hwm14/; make compile;
+
+download:
+	python get_models.py
+
+source: download
+	cp ./f2py/igrf11/* ./dl_models/igrf11/
+	cd ./dl_models/igrf11/; make source
+
+	cp ./f2py/igrf12/* ./dl_models/igrf12/
+	cd ./dl_models/igrf12/; make source
+
+	cp -v ./f2py/msis/* ./dl_models/msis/
+	cd ./dl_models/msis/; make source;
+
+	cp ./f2py/hwm93/* ./dl_models/hwm93/
+	cd ./dl_models/hwm93/; make source;
+
+	cp ./f2py/iri12/* ./dl_models/iri12/
+	cd ./dl_models/iri12/; make source;
+
+	cp ./f2py/iri16/* ./dl_models/iri16/
+	cd ./dl_models/iri16/; make source;
+
+	cp ./f2py/hwm07/* ./dl_models/hwm07/
+	cd ./dl_models/hwm07/; make source;
+
+	cd ./dl_models/hwm14/; make source;
 
 clean:
 	rm -rf *~
-	rm -rf ./dl_models/hwm93/*
+	make -Cdl_models/hwm93 clean
 	rm -rf ./dl_models/hwm07/*
 	rm -rf ./dl_models/hwm14/*.pyf
 	rm -rf ./dl_models/hwm14/out*
@@ -36,7 +54,7 @@ clean:
 	rm -rf ./dl_models/igrf12/*
 	rm -rf ./dl_models/iri12/*
 	rm -rf ./dl_models/iri16/*
-	rm -rf ./dl_models/msis/*
+	make -Cdl_models/msis clean
 	touch ./dl_models/hwm07/dummy.txt
 	touch ./dl_models/hwm93/dummy.txt
 	touch ./dl_models/igrf11/dummy.txt

--- a/pyglow/models/dl_models/hwm14/Makefile
+++ b/pyglow/models/dl_models/hwm14/Makefile
@@ -12,8 +12,10 @@ sig:
 mod:
 	f2py -c sig_file.pyf $(fortran_files) --f77flags="-std=legacy" | tee out2
 
-compile:
+source:
 	make sig;
+
+compile: source
 	make mod;
 
 

--- a/pyglow/models/f2py/hwm07/Makefile
+++ b/pyglow/models/f2py/hwm07/Makefile
@@ -25,9 +25,11 @@ sig:
 mod:
 	f2py -c sig_file.pyf $(fortran_files)  --fcompiler=gfortran | tee out2
 
-compile:
+source:
 	make patch_hwm07e;
 	make sig; 
+
+compile:
 	make mod;
 
 install:

--- a/pyglow/models/f2py/hwm07/Makefile
+++ b/pyglow/models/f2py/hwm07/Makefile
@@ -29,7 +29,7 @@ source:
 	make patch_hwm07e;
 	make sig; 
 
-compile:
+compile: source
 	make mod;
 
 install:

--- a/pyglow/models/f2py/hwm07/Makefile
+++ b/pyglow/models/f2py/hwm07/Makefile
@@ -16,7 +16,7 @@ checkhwm07_g95:
 	g95 -cpp checkhwm07.f90 hwm07e.f90 dwm07b.f90 apexcord.f90 -o checkhwm.x
 
 patch_hwm07e:
-	perl -p -e 's/\r//' < hwm07e.f90 > hwm07e_unix.f90
+	# perl -p -e 's/\r//' < hwm07e.f90 > hwm07e_unix.f90
 	patch hwm07e_unix.f90 -i hwm07e.patch -o hwm07e_modified.f90
 
 sig:

--- a/pyglow/models/f2py/hwm93/Makefile
+++ b/pyglow/models/f2py/hwm93/Makefile
@@ -3,27 +3,25 @@ mod = hwm93py
 only = gws5
 
 clean:
-	rm *~ *.x *.mod *.pyf out* *.so hwm93_modified.f
+	rm -f *~ *.x *.mod *.pyf out* *.so hwm93_modified.f
 
-patch_hwm93:
+hwm93_modified.f:
 	patch hwm93.f -i hwm93.patch -o hwm93_modified.f
 
-sig:
-	f2py -m $(mod) -h sig_file.pyf $(fortran_files) only: $(only) : | tee out1
+sig_file.pyf: $(fortran_files)
+	f2py -m $(mod) -h sig_file.pyf $^ only: $(only) : | tee out1
 
-patch_sig:
+sig_file_patched.pyf: sig_file.pyf
 	patch sig_file.pyf -i sig.patch -o sig_file_patched.pyf
 
-mod:
-	f2py -c sig_file_patched.pyf $(fortran_files) --f77flags="-std=legacy" | tee out2
+mod: sig_file_patched.pyf $(fortran_files) 
+	f2py -c $^ --f77flags="-std=legacy" | tee out2
 
 
 
-compile:
-	make patch_hwm93;
-	make sig;
-	make patch_sig;
-	make mod;
+compile: mod
+
+source: sig_file_patched.pyf $(fortran_files)
 
 install:
 	cp $(mod).so ../model_atmosphere/modules/

--- a/pyglow/models/f2py/igrf11/Makefile
+++ b/pyglow/models/f2py/igrf11/Makefile
@@ -30,7 +30,7 @@ source:
 	make sig;
 	make patch_sig;
 
-compile: souce
+compile: source
 	make mod;
 
 install:

--- a/pyglow/models/f2py/igrf11/Makefile
+++ b/pyglow/models/f2py/igrf11/Makefile
@@ -25,10 +25,12 @@ patch_sig:
 mod:
 	f2py -c sig_file_patched.pyf $(fortran_files) | tee out2
 
-compile:
+source:
 	make patch_igrf11;	
 	make sig;
 	make patch_sig;
+
+compile:
 	make mod;
 
 install:

--- a/pyglow/models/f2py/igrf11/Makefile
+++ b/pyglow/models/f2py/igrf11/Makefile
@@ -30,7 +30,7 @@ source:
 	make sig;
 	make patch_sig;
 
-compile:
+compile: souce
 	make mod;
 
 install:

--- a/pyglow/models/f2py/igrf12/Makefile
+++ b/pyglow/models/f2py/igrf12/Makefile
@@ -25,10 +25,12 @@ patch_sig:
 mod:
 	f2py -c sig_file_patched.pyf $(fortran_files) | tee out2
 
-compile:
+source:
 	make patch_igrf12;	
 	make sig;
 	make patch_sig;
+
+compile:
 	make mod;
 
 install:

--- a/pyglow/models/f2py/igrf12/Makefile
+++ b/pyglow/models/f2py/igrf12/Makefile
@@ -30,7 +30,7 @@ source:
 	make sig;
 	make patch_sig;
 
-compile:
+compile: source
 	make mod;
 
 install:

--- a/pyglow/models/f2py/iri12/Makefile
+++ b/pyglow/models/f2py/iri12/Makefile
@@ -46,8 +46,7 @@ source:
 	make patch_sig;
 
 
-compile:
-	make source;
+compile: source
 	make mod;
 
 install:

--- a/pyglow/models/f2py/iri12/Makefile
+++ b/pyglow/models/f2py/iri12/Makefile
@@ -39,11 +39,15 @@ mod:
 	f2py -c sig_file_patched.pyf $(fortran_files) --fcompiler=gfortran --f77flags="-std=legacy -w -O2 -fbacktrace -fno-automatic -fPIC" | tee out2
 
 
-compile:
-	make patch_iridreg
+source:
+	make patch_iridreg;
 	make patch_iriflip;
 	make sig;
 	make patch_sig;
+
+
+compile:
+	make source;
 	make mod;
 
 install:

--- a/pyglow/models/f2py/iri16/Makefile
+++ b/pyglow/models/f2py/iri16/Makefile
@@ -39,12 +39,14 @@ mod:
 	# This works well [1]
 	f2py -c sig_file_patched.pyf $(fortran_files) --fcompiler=gfortran --f77flags="$(f77flags)" | tee out2
 
-compile:
+source:
 	make patch_iridreg;
 	make patch_irisub;
 	make patch_iriflip;
 	make sig;
 	make patch_sig;
+
+compile:
 	make mod;
 
 install:

--- a/pyglow/models/f2py/iri16/Makefile
+++ b/pyglow/models/f2py/iri16/Makefile
@@ -46,7 +46,7 @@ source:
 	make sig;
 	make patch_sig;
 
-compile:
+compile: source
 	make mod;
 
 install:

--- a/pyglow/models/f2py/msis/Makefile
+++ b/pyglow/models/f2py/msis/Makefile
@@ -26,7 +26,7 @@ source:
 	make sig;
 	make patch_sig;
 
-compile:
+compile: source
 	make mod;
 
 install:

--- a/pyglow/models/f2py/msis/Makefile
+++ b/pyglow/models/f2py/msis/Makefile
@@ -3,7 +3,7 @@ mod = msis00py
 only = gtd7
 
 clean:
-	rm *~ *.x *.mod *.pyf out* *.so
+	rm -f *~ *.x *.mod *.pyf out* *.so
 
 msis_test:
 	gfortran -std=legacy -fno-automatic -O2 msis00_driver.f nrlmsise00.f -o msis_test.x
@@ -21,10 +21,12 @@ mod:
 	f2py -c sig_file_patched.pyf $(fortran_files) --f77flags="-std=legacy" | tee out2
 
 
-compile:
+source:
 	make patch_msis;
 	make sig;
 	make patch_sig;
+
+compile:
 	make mod;
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ msis00 = Extension(
 ext_modules = [igrf11,
                igrf12,
                hwm93,
-               hwm07,  # until encoding issue is resolved
+               hwm07,
                hwm14,
                iri12,
                iri16,

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ hwm93 = Extension(
 
 # Remove invalid unicode characters that appear in the comments
 def reencode(dosfile, target='utf-8'):
-    with open(dosfile, 'r', encoding=target, errors='ignore') as f:
+    with open(dosfile, 'r', encoding='cp1251', errors='ignore') as f:
         content = f.read()
     with open(dosfile, 'w', encoding=target) as f:
         f.write(content)


### PR DESCRIPTION
With these changes, extension modules are built by setup.py instead of make. This automatically handles the *.so file names correctly.

I have only tested this code on Arch Linux with Python 3.6.5 and 2.7.15, but it should work on any platform with a unixy environment and the usual prerequisites.

The original installation instructions will work here as well, but to avoid compiling everything twice I have added a `source` target in the makefiles, which downloads sources, generates signatures, and applies patches.
```bash
$ make -Cpyglow/models source
$ python setup.py install [--user --prefix=...]
```