### PR TITLE
python -> python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk update && apk add \
 
 # Install pyglow Python dependencies:
 COPY requirements.txt /
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 # Copy source code into container:
 COPY src/ /pyglow/src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /pyglow
 
 # Compile & install:
 RUN make -C src/pyglow/models source
-RUN python setup.py install --user
+RUN python3 setup.py install --user
 
 # Run unit tests:
-CMD python -m unittest test.test_suite_pyglow
+CMD python3 -m unittest test.test_suite_pyglow

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ First, checkout the repository:
 $ git clone git://github.com/timduly4/pyglow.git pyglow
 ```
 
-Change directories into the repository folder, compile the f2py bindings, then install the python package:
+Change directories into the repository folder, compile the f2py bindings, then install the Python package:
 ```
 $ cd pyglow/
 $ make -C src/pyglow/models source

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Change directories into the repository folder, compile the f2py bindings, then i
 ```
 $ cd pyglow/
 $ make -C src/pyglow/models source
-$ python setup.py install --user
+$ python3 setup.py install --user
 ```
 
 ### Individual installation steps:
@@ -84,19 +84,19 @@ $ make all
     ./dl_models/msis/msis00py.so
     ```
 
-(3) Install the python package
+(3) Install the Python package
 ```
 $ cd ../../../   # get back to root directory
-$ python setup.py install --user
+$ python3 setup.py install --user
 ```
-  * On a mac, the folder `pyglow` and `*.so` files from `./models/dl_models/<model>/` should be in `/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages`
+  * On a mac, the folder `pyglow` and `*.so` files from `./models/dl_models/<model>/` should be in `/Library/Frameworks/Python.framework/Versions/3.7/lib/python3.7/site-packages`
   * The `--user` flag installs the package locally (i.e., you do not need `sudo` access)
 
 # Unit tests
 
 See unit tests in `./test`.  For example, run the unittest suite with:
 
-`$ python -m unittest test.test_suite_pyglow`
+`$ python3 -m unittest test.test_suite_pyglow`
 
 (Be sure that the f2py modules have been compiled via `$ make -C src/pyglow/models source`, first.)
 
@@ -127,14 +127,14 @@ You'll need to download the geophysical indices as they become available.  The `
 
 ```
 # Grabs indices between 2016 and 2018:
-$ python -c "import pyglow; pyglow.update_indices(2016, 2018)"
+$ python3 -c "import pyglow; pyglow.update_indices(2016, 2018)"
 ```
 
 Note: you only need to run this function when you would like to update the indices.
 
 You can check if you have geophysical indices between dates with:
 ```
-$ python -c "import pyglow;  pyglow.check_stored_indices('2015-01-01', '2019-01-01')"
+$ python3 -c "import pyglow;  pyglow.check_stored_indices('2015-01-01', '2019-01-01')"
 
 Checking: input date range:
   2015-01-01
@@ -145,12 +145,12 @@ Checking: input date range:
 
 # Uninstallation
 
-The install directory for pyglow can be outputted via `python -c "import pyglow; print(pyglow.__file__)"`.  For example:
+The install directory for pyglow can be outputted via `python3 -c "import pyglow; print(pyglow.__file__)"`.  For example:
 ```
-~ $ python -c "import pyglow; print(pyglow.__file__)"
-/Users/duly/Library/Python/2.7/lib/python/site-packages/pyglow/__init__.pyc
+~ $ python3 -c "import pyglow; print(pyglow.__file__)"
+/Users/duly/Library/Python/3.7/lib/python/site-packages/pyglow/__init__.pyc
 ```
 This tells you the installation location, and then you can remove the package with:
 ```
-~ $ rm -rf /Users/duly/Library/Python/2.7/lib/python/site-packages/pyglow
+~ $ rm -rf /Users/duly/Library/Python/3.7/lib/python/site-packages/pyglow
 ```

--- a/examples/test_airglow.py
+++ b/examples/test_airglow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 Profile 7774 and 6300-nm emissions.
@@ -53,5 +53,3 @@ plt.title(
 plt.legend(loc=1, fontsize=10)
 plt.draw()
 plt.show()
-
-

--- a/examples/test_iri12_iri16.py
+++ b/examples/test_iri12_iri16.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Profile plot to compare IRI 2012 and IRI 2016.
 '''
@@ -30,7 +30,7 @@ for alt in alts:
     ne_2012.append(pt.ne)
 
 # Plot
-plt.figure(1); 
+plt.figure(1);
 plt.clf()
 plt.semilogx(ne_2016, alts, 'bo-', label='IRI Model Year: 2016')
 plt.semilogx(ne_2012, alts, 'r.--', label='IRI Model Year: 2012')
@@ -42,9 +42,3 @@ plt.title('%s UT, lat=%3.1f$^\circ$, lon=%3.1f$^\circ$' %\
 plt.legend(loc=0)
 plt.draw()
 plt.show()
-
-
-
-
-
-

--- a/examples/test_ne_airglow_profile.py
+++ b/examples/test_ne_airglow_profile.py
@@ -1,9 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Example Python script using pyglow
 and its climatological models
 to plot profile of airglow emission.
-and electron density 
+and electron density
 """
 
 import matplotlib

--- a/examples/test_user_indices.py
+++ b/examples/test_user_indices.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 from datetime import datetime
 

--- a/examples/test_version_keywords.py
+++ b/examples/test_version_keywords.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 '''
 Testing out the different 'version' keywords
@@ -37,5 +37,3 @@ try:
     pt.run_iri(version=2020) # should fail
 except ValueError as e:
     print("Caught an exception: `{}`".format(e))
-
-

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import glob
 import os

--- a/src/pyglow/models/Makefile
+++ b/src/pyglow/models/Makefile
@@ -17,7 +17,7 @@ all: source
 	cd ./dl_models/hwm14/; make compile; rsync hwm14py*so hwm14py.so
 
 download:
-	python get_models.py
+	python3 get_models.py
 
 source: clean download
 	cp ./f2py/igrf11/* ./dl_models/igrf11/

--- a/src/pyglow/models/f2py/hwm07/Makefile
+++ b/src/pyglow/models/f2py/hwm07/Makefile
@@ -25,7 +25,7 @@ sig:
 mod:
 	f2py -c sig_file.pyf $(fortran_files)  --fcompiler=gfortran | tee out2
 remove_decode_errors:
-	python remove_decode_errors.py
+	python3 remove_decode_errors.py
 source:
 	make remove_decode_errors;
 	make patch_hwm07e;

--- a/src/pyglow/models/f2py/iri12/Makefile
+++ b/src/pyglow/models/f2py/iri12/Makefile
@@ -22,7 +22,7 @@ patch_iridreg:
 	patch iridreg.for -i iridreg.patch -o iridreg_modified.for
 
 patch_iriflip:
-	python delete_iriflip_comments.py
+	python3 delete_iriflip_comments.py
 	#patch iriflip.for -i iriflip.patch -o iriflip_modified.for
 
 sig:
@@ -55,7 +55,7 @@ install:
 
 
 
-#   [1]  I had a huge bug where iri was not repeating itself on python calls. I found
+#   [1]  I had a huge bug where iri was not repeating itself on Python calls. I found
 # this github https://github.com/sdelarquier/iri and the compiler options
 #   	f2py --overwrite-signature irisub.for -m ${MODULE} -h iri.pyf
 #   	gfortran -w -O2 -fbacktrace -fno-automatic -fPIC -c *.for

--- a/src/pyglow/models/f2py/iri16/Makefile
+++ b/src/pyglow/models/f2py/iri16/Makefile
@@ -22,7 +22,7 @@ patch_iridreg:
 	patch iridreg.for -i iridreg.patch -o iridreg_modified.for
 
 patch_iriflip:
-	python delete_iriflip_comments.py
+	python3 delete_iriflip_comments.py
 
 sig:
 	f2py -m $(mod) -h sig_file.pyf $(fortran_files) only: $(only) : | tee out1
@@ -47,7 +47,7 @@ compile: source
 install:
 	cp $(mod).so ../model_atmosphere/modules/
 
-#   [1]  I had a huge bug where iri was not repeating itself on python calls. I found
+#   [1]  I had a huge bug where iri was not repeating itself on Python calls. I found
 # this github https://github.com/sdelarquier/iri and the compiler options
 #   	f2py --overwrite-signature irisub.for -m ${MODULE} -h iri.pyf
 #   	gfortran -w -O2 -fbacktrace -fno-automatic -fPIC -c *.for

--- a/src/pyglow/pyglow.py
+++ b/src/pyglow/pyglow.py
@@ -293,7 +293,7 @@ class Point(object):
         ------
         9/9/13 -- implemented into pyglow
                   based on Jonathan J. Makela's MATLAB
-                  and subsequent python code
+                  and subsequent Python code
         9/13/16 -- added 7774 calculation
         """
 


### PR DESCRIPTION
Use `python3` in scripts over `python`.