### PR TITLE
use python instead of python3

### DIFF
--- a/src/pyglow/models/Makefile
+++ b/src/pyglow/models/Makefile
@@ -17,7 +17,7 @@ all: source
 	cd ./dl_models/hwm14/; make compile; rsync hwm14py*so hwm14py.so
 
 download:
-	python3 get_models.py
+	python get_models.py
 
 source: clean download
 	cp ./f2py/igrf11/* ./dl_models/igrf11/


### PR DESCRIPTION
The makefile uses `python3` which breaks installation inside python2 virtual environments.