### PR TITLE
This commit fixes the discontinuity when dealing with HWM/DWM. One ca…

### DIFF
--- a/src/pyglow/geophysical_indices.py
+++ b/src/pyglow/geophysical_indices.py
@@ -24,6 +24,7 @@ class Indice(object):
         self.ap_daily = nan
         self.dst = nan
         self.ae = nan
+        self.ap1 = nan
 
         # AP values for MSIS:
         self.apmsis = [nan, ] * 7
@@ -34,7 +35,7 @@ class Indice(object):
         """
 
         # Geophysical indices:
-        kp, ap, f107, f107a, f107p, kp_daily, ap_daily, dst, ae = \
+        kp, ap, f107, f107a, f107p, kp_daily, ap_daily, dst, ae, ap1 = \
             get_kpap(self.dn)
 
         # Assign to member variables:
@@ -47,6 +48,7 @@ class Indice(object):
         self.ap_daily = ap_daily
         self.dst = dst
         self.ae = ae
+        self.ap1 = ap1
 
         # AP values for MSIS:
         self.apmsis = get_apmsis(self.dn)

--- a/src/pyglow/get_apmsis.py
+++ b/src/pyglow/get_apmsis.py
@@ -33,32 +33,32 @@ def get_apmsis(dn):
 
     Outputs:
     --------
-        out : a 1x7 array of the caclulated ap indices
+        out : a 1x7 array of the calculated ap indices
 
     History:
     --------
         7/21/12 Created, Timothy Duly (duly2@illinois.edu)
 
     """
-    out = float('nan')*np.zeros(7)
+    out = float('nan')*np.zeros(8)
 
     # (1) DAILY AP
-    _, ap, _, _, _, _, daily_ap, _, _ = get_kpap(dn)
+    _, ap, _, _, _, _, daily_ap, _, _, ap1 = get_kpap(dn)
     out[0] = daily_ap
 
     # (2) 3 HR AP INDEX FOR CURRENT TIME
     out[1] = ap
 
     # (3) 3 HR AP INDEX FOR 3 HRS BEFORE CURRENT TIME
-    _, ap, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-3))
+    _, ap, _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-3))
     out[2] = ap
 
     # (4) 3 HR AP INDEX FOR 6 HRS BEFORE CURRENT TIME
-    _, ap, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-6))
+    _, ap, _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-6))
     out[3] = ap
 
     # (5) 3 HR AP INDEX FOR 9 HRS BEFORE CURRENT TIME
-    _, ap, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-9))
+    _, ap, _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-9))
     out[4] = ap
 
     # (6) AVERAGE OF EIGHT 3 HR AP INDICIES FROM 12 TO 33 HRS
@@ -66,14 +66,14 @@ def get_apmsis(dn):
 
     temp = np.zeros(8)
 
-    _, temp[0], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-12))
-    _, temp[1], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-15))
-    _, temp[2], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-18))
-    _, temp[3], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-21))
-    _, temp[4], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-24))
-    _, temp[5], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-27))
-    _, temp[6], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-30))
-    _, temp[7], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-33))
+    _, temp[0], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-12))
+    _, temp[1], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-15))
+    _, temp[2], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-18))
+    _, temp[3], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-21))
+    _, temp[4], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-24))
+    _, temp[5], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-27))
+    _, temp[6], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-30))
+    _, temp[7], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-33))
 
     out[5] = np.nan if all(np.isnan(temp)) else np.nanmean(temp)
 
@@ -82,15 +82,18 @@ def get_apmsis(dn):
 
     temp = np.zeros(8)
 
-    _, temp[0], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-36))
-    _, temp[1], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-39))
-    _, temp[2], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-42))
-    _, temp[3], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-45))
-    _, temp[4], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-48))
-    _, temp[5], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-51))
-    _, temp[6], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-54))
-    _, temp[7], _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-57))
+    _, temp[0], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-36))
+    _, temp[1], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-39))
+    _, temp[2], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-42))
+    _, temp[3], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-45))
+    _, temp[4], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-48))
+    _, temp[5], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-51))
+    _, temp[6], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-54))
+    _, temp[7], _, _, _, _, _, _, _, _ = get_kpap(dn+timedelta(hours=-57))
 
     out[6] = np.nan if all(np.isnan(temp)) else np.nanmean(temp)
 
+    # (8) CUBIC INTERPOLATED AP INDEX AT THE TIME dn
+
+    out[7] = ap1
     return out

--- a/src/pyglow/get_kpap.py
+++ b/src/pyglow/get_kpap.py
@@ -9,6 +9,86 @@ from . import generate_kpap
 # Fetch geophysical indices (Global variable to make it fast):
 GEOPHYSICAL_INDICES = generate_kpap.fetch()
 
+def cubic_interp1d(x0, x, y):
+    """
+    Interpolate a 1-D function using cubic splines.
+      x0 : a float or an 1d-array
+      x : (N,) array_like
+          A 1-D array of real/complex values.
+      y : (N,) array_like
+          A 1-D array of real values. The length of y along the
+          interpolation axis must be equal to the length of x.
+
+    Implement a trick to generate at first step the cholesky matrice L of
+    the tridiagonal matrice A (thus L is a bidiagonal matrice that
+    can be solved in two distinct loops).
+
+    additional ref: www.math.uh.edu/~jingqiu/math4364/spline.pdf
+    """
+    x = np.asfarray(x)
+    y = np.asfarray(y)
+
+    # remove non finite values
+    # indexes = np.isfinite(x)
+    # x = x[indexes]
+    # y = y[indexes]
+
+    # check if sorted
+    if np.any(np.diff(x) < 0):
+        indexes = np.argsort(x)
+        x = x[indexes]
+        y = y[indexes]
+
+    size = len(x)
+
+    xdiff = np.diff(x)
+    ydiff = np.diff(y)
+
+    # allocate buffer matrices
+    Li = np.empty(size)
+    Li_1 = np.empty(size-1)
+    z = np.empty(size)
+
+    # fill diagonals Li and Li-1 and solve [L][y] = [B]
+    Li[0] = (2*xdiff[0])**.5
+    Li_1[0] = 0.0
+    B0 = 0.0 # natural boundary
+    z[0] = B0 / Li[0]
+
+    for i in range(1, size-1, 1):
+        Li_1[i] = xdiff[i-1] / Li[i-1]
+        Li[i] = (2*(xdiff[i-1]+xdiff[i]) - Li_1[i-1] * Li_1[i-1])**.5
+        Bi = 6*(ydiff[i]/xdiff[i] - ydiff[i-1]/xdiff[i-1])
+        z[i] = (Bi - Li_1[i-1]*z[i-1])/Li[i]
+
+    i = size - 1
+    Li_1[i-1] = xdiff[-1] / Li[i-1]
+    Li[i] = (2*xdiff[-1] - Li_1[i-1] * Li_1[i-1])**.5
+    Bi = 0.0 # natural boundary
+    z[i] = (Bi - Li_1[i-1]*z[i-1])/Li[i]
+
+    # solve [L.T][x] = [y]
+    i = size-1
+    z[i] = z[i] / Li[i]
+    for i in range(size-2, -1, -1):
+        z[i] = (z[i] - Li_1[i-1]*z[i+1])/Li[i]
+
+    # find index
+    index = x.searchsorted(x0)
+
+    np.clip(index, 1, size-1, index)
+
+    xi1, xi0 = x[index], x[index-1]
+    yi1, yi0 = y[index], y[index-1]
+    zi1, zi0 = z[index], z[index-1]
+    hi1 = xi1 - xi0
+
+    # calculate cubic
+    f0 = zi0/(6*hi1)*(xi1-x0)**3 + \
+         zi1/(6*hi1)*(x0-xi0)**3 + \
+         (yi1/hi1 - zi1*hi1/6)*(x0-xi0) + \
+         (yi0/hi1 - zi0*hi1/6)*(xi1-x0)
+    return f0
 
 def get_kpap(dn):
     """
@@ -22,7 +102,9 @@ def get_kpap(dn):
 
     Outputs:
     --------
-        kp, ap, f107, f107a, f107p, daily_kp, daily_ap, dst, ae
+        kp, ap, f107, f107a, f107p, daily_kp, daily_ap, dst, ae, ap1
+
+        ap1 == the interpolated ap index to avoid DWM discontinuities
 
     History:
     --------
@@ -33,8 +115,25 @@ def get_kpap(dn):
     day_index = (dn_floor - generate_kpap.EPOCH).days
     hour_index = int(np.floor(dn.hour/3.))
 
+
     kp = GEOPHYSICAL_INDICES[hour_index, day_index]
     ap = GEOPHYSICAL_INDICES[hour_index+8, day_index]
+
+    apall = GEOPHYSICAL_INDICES[:, day_index - 1][8:16]
+    apall = np.append(apall,GEOPHYSICAL_INDICES[:, day_index][8:16])
+    apall = np.append(apall,GEOPHYSICAL_INDICES[:, day_index + 1][8:16])
+
+    aphours = np.array([1.5, 4.5, 7.5, 10.5, 13.5, 16.5, 19.5, 22.5])
+    aphours = np.arange(-22.5,48,3)
+    mestime = dn.hour+dn.minute/60.+dn.second/3600.
+    aphoursn= np.sort(np.append(np.linspace(np.min(aphours),np.max(aphours),10000),mestime))
+
+    aphours = aphours[~np.isnan(apall)]
+    apall = apall[~np.isnan(apall)]
+
+
+    ap1 = cubic_interp1d([mestime,mestime], aphours, apall)[0]
+
     f107 = GEOPHYSICAL_INDICES[16, day_index]
     f107a = GEOPHYSICAL_INDICES[17, day_index]
     f107p = GEOPHYSICAL_INDICES[16, day_index-1]
@@ -45,4 +144,4 @@ def get_kpap(dn):
     dst = GEOPHYSICAL_INDICES[20+dn.hour, day_index]
     ae = GEOPHYSICAL_INDICES[44+dn.hour, day_index]
 
-    return kp, ap, f107, f107a, f107p, daily_kp, daily_ap, dst, ae
+    return kp, ap, f107, f107a, f107p, daily_kp, daily_ap, dst, ae, ap1

--- a/src/pyglow/hwm.py
+++ b/src/pyglow/hwm.py
@@ -24,7 +24,7 @@ class HWM(object):
             self.data_path_stub = "src/pyglow/models/dl_models"
             self.testing_data_stub = True
 
-    def run(self, location_time, version, dwm = 'off',
+    def run(self, location_time, version, dwm = 'on',
             f107=None, f107a=None, ap=None, ap_daily=None, ap1 = None):
         """
         Wrapper to call various HWM models

--- a/src/pyglow/hwm.py
+++ b/src/pyglow/hwm.py
@@ -15,7 +15,7 @@ class HWM(object):
         self.u = nan
         self.v = nan
         self.hwm_version = None
-
+        self.hwm_dwm = None
         # Data path:
         self.data_path_stub = DIR_FILE
         self.testing_data_stub = False
@@ -24,18 +24,27 @@ class HWM(object):
             self.data_path_stub = "src/pyglow/models/dl_models"
             self.testing_data_stub = True
 
-    def run(self, location_time, version,
-            f107=None, f107a=None, ap=None, ap_daily=None):
+    def run(self, location_time, version, dwm = 'off',
+            f107=None, f107a=None, ap=None, ap_daily=None, ap1 = None):
         """
         Wrapper to call various HWM models
 
         :param location_time: Instance of LocationTime
         :param version: Version of HWM to run
+        :param dwm: How to do DWM -> 'on','off',interpolated
         :param f107: f107 indice (used for 93, 07)
         :param f107a: f107a indice (used for 93, 07)
         :param ap: ap indice (used for 07, 14)
         :param ap_daily: ap_daily indice (used for 93)
         """
+        if dwm == 'off':
+            ap = -1
+        elif dwm == 'on':
+            ap = ap
+        elif dwm == 'smooth':
+            ap = ap1
+
+        self.hwm_dwm = dwm
 
         # HWM93:
         if version == 1993:

--- a/src/pyglow/pyglow.py
+++ b/src/pyglow/pyglow.py
@@ -102,6 +102,7 @@ class Point(object):
         self.ap_daily = self.indice.ap_daily
         self.dst = self.indice.dst
         self.ae = self.indice.ae
+        self.ap1 = self.indice.ap1
         self.apmsis = self.indice.apmsis
 
         # For msis:
@@ -115,6 +116,7 @@ class Point(object):
         self.u = self.hwm.u
         self.v = self.hwm.v
         self.hwm_version = self.hwm.hwm_version
+        self.hwm_dwm = self.hwm.hwm_dwm
 
         # For igrf:
         self.igrf = IGRF()
@@ -218,9 +220,23 @@ class Point(object):
 
         return self
 
-    def run_hwm(self, version=2014):
+    def run_hwm(self, version=2014, dwm = 'off'):
         """
         Executes HWM and assigns results to instance.
+
+        Call examples:
+
+        - run_hwm(version=2014, dwm='off') # Default, with ap=-1
+
+        - run_hwm(version=2014, dwm='on')  # Standard DWM -- this can cause
+                                           # discontinuities in the wind due
+                                           # to the usage of the 3-hour ap to
+                                           # drive DWM.
+
+        - run_hwm(version=2014, dwm='smooth')   # This is our modified DWM:
+                                                # It interpolates the 3-hour
+                                                # ap index into a smooth curve
+                                                # using a cubic interpolation.
 
         :param version: Version of HWM to run
         """
@@ -229,16 +245,19 @@ class Point(object):
         self.hwm.run(
             self.location_time,
             version,
+            dwm,
             f107=self.f107,
             f107a=self.f107a,
             ap=self.ap,
             ap_daily=self.ap_daily,
+            ap1=self.ap1
         )
 
         # Assign output:
         self.u = self.hwm.u
         self.v = self.hwm.v
         self.hwm_version = self.hwm.hwm_version
+        self.hwm_dwm = self.hwm.hwm_dwm
 
         return self
 

--- a/src/pyglow/pyglow.py
+++ b/src/pyglow/pyglow.py
@@ -220,18 +220,19 @@ class Point(object):
 
         return self
 
-    def run_hwm(self, version=2014, dwm = 'off'):
+    def run_hwm(self, version=2014, dwm = 'on'):
         """
         Executes HWM and assigns results to instance.
 
         Call examples:
+        - run_hwm(version=2014, dwm='on')  # Default setting: Standard DWM
+                                           # this can cause discontinuities
+                                           # in the wind due to the usage of
+                                           # the 3-hour ap to drive DWM.
 
         - run_hwm(version=2014, dwm='off') # Default, with ap=-1
 
-        - run_hwm(version=2014, dwm='on')  # Standard DWM -- this can cause
-                                           # discontinuities in the wind due
-                                           # to the usage of the 3-hour ap to
-                                           # drive DWM.
+
 
         - run_hwm(version=2014, dwm='smooth')   # This is our modified DWM:
                                                 # It interpolates the 3-hour

--- a/tester.py
+++ b/tester.py
@@ -37,7 +37,7 @@ for lat in np.arange(45,75.1, 5):
     FFF107a = []
 
     apn = 0
-    for dwm in ['off', 'on', 'smooth']:
+    for dwm in [None, 'off','smooth']:
         UUU, VVV = [], []
         TIME = []
         for hour in np.arange(0, 24):
@@ -61,14 +61,19 @@ for lat in np.arange(45,75.1, 5):
         if dwm == 'off':
             linestyle = '--'
             linewidth = 0.5
-        elif dwm == 'on':
+        elif (dwm == 'on') or (dwm == None):
             linestyle = '-'
             linewidth = 0.5
         else:
             linestyle = '-'
             linewidth = 1.0
-        ax[0, 0].plot(TIME, UUU, color='blue', linestyle=linestyle, linewidth=linewidth, label=dwm.capitalize())
-        ax[0, 1].plot(TIME, VVV, color='red', linestyle=linestyle, linewidth=linewidth, label=dwm.capitalize())
+
+        if dwm == None:
+            label = 'None'
+        else:
+            label = dwm.capitalize()
+        ax[0, 0].plot(TIME, UUU, color='blue', linestyle=linestyle, linewidth=linewidth, label=label)
+        ax[0, 1].plot(TIME, VVV, color='red', linestyle=linestyle, linewidth=linewidth, label=label)
 
         apn = apn + 1
     ax[1, 0].plot(TIME, AP, color='black', linestyle='-', label='Ap')

--- a/tester.py
+++ b/tester.py
@@ -1,0 +1,98 @@
+from datetime import datetime as dt
+import matplotlib.pyplot as plt
+from src import pyglow
+import numpy as np
+import os
+
+'''
+This script shows the HWM/DWM test.
+'''
+
+AP0 = []
+AP1 = []
+TIME = []
+lat = 0
+lon = -145
+
+indd = 0
+
+for lat in np.arange(45,75.1, 5):
+
+    fig, ax = plt.subplots(nrows=2, ncols=2, figsize=(10, 5), sharex=True)
+
+    fig.subplots_adjust(hspace=0, wspace=0)
+    fig.suptitle('Ap index effect and DWM test at Latitude = %2.1f'%lat, fontsize=16)
+    for i in range(2):
+        ax[-1, i].set_xlabel('UT (hours of 2023/02/17)')
+        for j in range(2):
+
+            if i == 0:
+                if j < 1:
+                    ax[j, 0].set_ylabel('Winds\n(m/s)', weight='bold')
+                else:
+                    ax[j, 0].set_ylabel('Ap index', weight='bold')
+    AP = []
+    AP1 = []
+    FFF107 = []
+    FFF107a = []
+
+    apn = 0
+    for dwm in ['off', 'on', 'smooth']:
+        UUU, VVV = [], []
+        TIME = []
+        for hour in np.arange(0, 24):
+            for minute in np.arange(0, 60, 30):
+                dn = dt(2023, 2, 17, hour, minute, 30)
+                TIME.append(hour + minute / 60. + 30 / 3600.)
+
+                pt = pyglow.Point(dn, lat, lon, 250)
+                pt.run_hwm(version=2014, dwm=dwm)
+
+                Vhwm = pt.v
+                Uhwm = pt.u
+
+                UUU.append(Uhwm)
+                VVV.append(Vhwm)
+                if apn == 0:
+                    AP.append(pt.ap)
+                    AP1.append(pt.ap1)
+                    FFF107.append(pt.f107)
+                    FFF107a.append(pt.f107a)
+        if dwm == 'off':
+            linestyle = '--'
+            linewidth = 0.5
+        elif dwm == 'on':
+            linestyle = '-'
+            linewidth = 0.5
+        else:
+            linestyle = '-'
+            linewidth = 1.0
+        ax[0, 0].plot(TIME, UUU, color='blue', linestyle=linestyle, linewidth=linewidth, label=dwm.capitalize())
+        ax[0, 1].plot(TIME, VVV, color='red', linestyle=linestyle, linewidth=linewidth, label=dwm.capitalize())
+
+        apn = apn + 1
+    ax[1, 0].plot(TIME, AP, color='black', linestyle='-', label='Ap')
+    ax[1, 1].plot(TIME, AP1, color='black', linestyle='-', label='Ap modified')
+
+    ax[1, 1].text(1.035, 0.5, 'Ap', rotation=90, horizontalalignment='center',
+                  verticalalignment='center', transform=ax[1, 1].transAxes)
+
+    ax[0, 0].set_title('Zonal')
+    ax[0, 1].set_title('Meridional')
+
+    for i in range(2):
+        for j in range(2):
+            ax[j, i].grid()
+            ax[j, i].legend(loc='best')
+            if j < 1:
+                ax[j, i].set_ylim(-130, 130)
+            else:
+                ax[j, i].set_ylim(0, 21)
+            ax[j, i].locator_params(axis='y', nbins=7)
+            plt.setp(ax[j, 1].get_yticklabels()[:], visible=False)
+
+    plt.savefig(os.getcwd() + '/DWM_Test_%03d.png' % indd,
+                bbox_inches='tight', dpi=300)
+    indd = indd + 1
+    print('DWM Test at %2.2f' % lat)
+    plt.close()


### PR DESCRIPTION
…n now use 'off' (default), 'on', or 'smooth'. The code does that by fetching the Ap index from 3 days (the day in the datetime used in pyglow.Point, a day before and a day after), then performing a cubic interpolation to smooth out the Ap values (which are only calculated to every 3 hours).

Lastly, a script called 'tester.py' is placed for testing the validity of this procedure by plotting the 3-hour Ap, the smooth Ap, and HWM14 winds (with 'on', 'off', and 'smooth' flags) vs time.

A later commit should feature the Hp index (which is defined the same way as the Ap, but its calculation is at every 30 minutes - see https://www.gfz-potsdam.de/en/hpo-index for details).